### PR TITLE
Change icon for "drizzle" to 'weather-showers'.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -498,7 +498,7 @@ WeatherMenuButton.prototype = {
             case 8:/* freezing drizzle */
                 return ['weather-freezing-rain', 'weather-showers'];
             case 9:/* drizzle */
-                return ['weather-fog'];
+                return ['weather-showers'];
             case 10:/* freezing rain */
                 return ['weather-freezing-rain', 'weather-showers'];
             case 11:/* showers */


### PR DESCRIPTION
Before, the icon for _drizzle_ (which means "light rain") was _'weather-fog'_, which doesn't make sense in my opinion.
