### PR TITLE
Disabled failing dh_auto_test in deb packages building - added line "override_dh_auto_test:" into debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,3 +5,4 @@
 
 override_dh_auto_configure:
 	./autogen.sh --prefix=/usr
+override_dh_auto_test:


### PR DESCRIPTION
Accept my patch only of Ubuntu packages will be build successfully :)
See today's build status at https://code.launchpad.net/~baltix/+recipe/gnome-shell-extension-weather

Disabled failing dh_auto_test in deb packages building - added line "override_dh_auto_test:" into debian/rules
