### PR TITLE
What do you think about using gnome-shell-extensions team repository https://launchpad.net/~gnome-shell-extensions/+archive as official repository for Ubuntu?

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ Currently, the weather report, including forecasts for today and tomorrow, is fe
 
 ## Through a package manager
 
-### [Ubuntu](https://launchpad.net/~xeked/+archive/gnome/+packages)
+### [Ubuntu, Mint, Debian and derivatives](https://launchpad.net/~gnome-shell-extensions/+archive/ppa/+packages)
 
-Add the PPA **ppa:xeked/gnome** to your source list, import the key **0B5C004838624188** from `keyserver.ubuntu.com`, update the package list and install **gnome-shell-extension-weather**:
+Add the PPA **ppa:gnome-shell-extensions** to your source list, update the package list and install **gnome-shell-extension-weather**:
 
-	sudo add-apt-repository ppa:xeked/gnome
-	sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0B5C004838624188
+	sudo add-apt-repository ppa:gnome-shell-extensions
 	sudo apt-get update
 	sudo apt-get install gnome-shell-extension-weather
 	


### PR DESCRIPTION
Hi Christian,

I think it's better to use "gnome-shell-extensions" team repository https://launchpad.net/~gnome-shell-extensions/+archive/ppa as official repository for gnome-shell-extension-weather instead of yours private (ppa:xeked/gnome). Most Ubuntu users don't trust private repositories, also it would be easier to fix problems in packages for other gnome-shell-extensions team members, who really use Ubuntu, like me :)

I've already configured daily builds in ppa:gnome-shell-extensions and you have administration rights in gnome-shell-extensions team, so you can always do what you think is better :)

Btw, I also simplified the instructions for Ubuntu - key is automatically imported when 'add-apt-repository' command is used and mentioned compatible distributions, like LinuxMint and Debian :)

Please accept my improvements :)
