### PR TITLE
Add GNOME Shell 3.14 as compatible version in metadata.json

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather",
 "description": "A simple extension for displaying weather information from several cities in GNOME Shell",
-"shell-version": [ "3.8", "3.10", "3.12" ],
+"shell-version": [ "3.8", "3.10", "3.12", "3.14" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }


### PR DESCRIPTION
I've tested this on Arch Linux and haven't noticed any regressions so far.
