### PR TITLE
Update shell-version in metadata.json

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather",
 "description": "A simple extension for displaying weather information from several cities in GNOME Shell",
-"shell-version": [ "3.8", "3.10", "3.12", "3.14" ],
+"shell-version": [ "3.8", "3.10", "3.12", "3.14", "3.16" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }


### PR DESCRIPTION
Your lovely extension runs fine with gnome 3.16