### PR TITLE
Remove GWeather.Provider.IWIN from enabled list

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -163,8 +163,7 @@ const WEATHER_DEBUG_EXTENSION = 'debug-extension';			// Weather extension settin
 
 			this.info.set_enabled_providers(GWeather.Provider.METAR |
 					                GWeather.Provider.OWM |
-							GWeather.Provider.YR_NO |
-							GWeather.Provider.IWIN);
+							GWeather.Provider.YR_NO);
 
 			this.infoC = this.info.connect("updated",function(){that.refresh();that.status(0);});	this.status("Information connection started");
 			}


### PR DESCRIPTION
GWeather.Provider.IWIN started failing within the last 48 hours,
with gnome-shell repeatedly logging the following message:
`GWeather-WARNING **: Failed to get IWIN forecast data: 403 Forbidden`

Removing IWIN from the enabled_providers list restores functionality.