### PR TITLE
Add GNOME Shell 3.18 as compatible version in metadata.json

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather",
 "description": "A simple extension for displaying weather information from several cities in GNOME Shell",
-"shell-version": [ "3.8", "3.10", "3.12", "3.14", "3.16" ],
+"shell-version": [ "3.8", "3.10", "3.12", "3.14", "3.16", "3.18" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }


### PR DESCRIPTION
Works for me (and [others](https://github.com/Neroth/gnome-shell-extension-weather/issues/225#issuecomment-143403424)).