### PR TITLE
Fix for #242

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -145,7 +145,7 @@ const WEATHER_DEBUG_EXTENSION = 'debug-extension';			// Weather extension settin
 		return 0;
 		},
 
-		world : GWeather.Location.new_world(false),
+		world : GWeather.Location.get_world(),
 
 		start : function()
 		{												this.status("Starting Weather");

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -97,7 +97,7 @@ Extends: Gtk.Box,
 
 	Window : new Gtk.Builder(),
 
-	world : GWeather.Location.new_world(false),
+	world : GWeather.Location.get_world(),
 
 	initWindow : function()
 	{												this.status("Init window");


### PR DESCRIPTION
GWeather API has been changed recently, there is no more GWeather.Location.new_world, instead there is GWeather.Location.get_world. Please see https://wiki.gnome.org/Projects/LibGWeather ("Improving libgweather" section).